### PR TITLE
Update readme, fix building of parameters when no metadata is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,12 @@ pip install omigami
 Huber F, Ridder L, Verhoeven S, Spaaks JH, Diblen F, Rogers S, et al. (2021) Spec2Vec: Improved mass spectral similarity scoring through learning of structural relationships. PLoS Comput Biol 17(2): e1008724. https://doi.org/10.1371/journal.pcbi.1008724
 
 ## Motivation
-
-TODO
+Motivation
+We aim to support metabolomics research by providing the following :
+- Easy-to-use tools
+- Access and scalability to the newest algorithms
+- Maintenance, support and documentation of software, models and data
+- A community of metabolomics researchers via our [Slack](https://join.slack.com/t/ml4metabolomics/shared_invite/zt-r39udtdg-G36YE6GQt1YdVIwTdeT8aw)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 A package to access Omigami services.
 
 ## Installation
+Omigami supports python 3.7 and 3.8. To install it, simply:
 
 ```sh
 pip install omigami
@@ -48,6 +49,14 @@ result = client.match_spectra_from_path(
     mgf_file_path, n_best_matches, include_metadata
 )
 ```
+
+The supported metadata keys for omigami are (case insensitive):
+- "smiles",
+- "compound_name",
+- "instrument",
+- "parent_mass",
+- "inchikey_smiles",
+- "inchikey_inchi"
 
 #### Notebooks
 You can find a [tutorial](https://github.com/omigami/omigami/blob/master/notebooks/spec2vec/tutorial.ipynb) notebook in the `/notebooks/` folder.

--- a/notebooks/spec2vec/tutorial.ipynb
+++ b/notebooks/spec2vec/tutorial.ipynb
@@ -40,12 +40,12 @@
    "outputs": [],
    "source": [
     "# Load your own MS/MS dataset (and skip the next cell)\n",
-    "path_to_mgf = f'/path/to/local_dataset.mgf'"
+    "path_to_mgf = 'GNPS-COLLECTIONS-MISC.mgf'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -53,18 +53,7 @@
     "id": "hfGUAXVbqUEx",
     "outputId": "244423a2-79ff-42c5-b13c-7c98afeca797"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "('GNPS-COLLECTIONS-MISC.mgf', <http.client.HTTPMessage at 0x7f9f11744880>)"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# OR download a small MS/MS dataset from GNPS, in the same directory as this notebook\n",
     "import urllib.request\n",
@@ -101,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "id": "fLx7vmXRIjIg"
    },
@@ -112,24 +101,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {
     "id": "BHMpFDN2Pq8Z"
    },
    "outputs": [],
    "source": [
     "# Initialize the client with your user token\n",
-    "spec2vec = Spec2Vec(token=\"5iTy7vACUXmlLO9fwGAL8v2WLPbo1SNH\")"
+    "spec2vec = Spec2Vec(token=\"your_token\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Run Spec2Vec library search\n",
-    "spectra_matches = spec2vec.match_spectra_from_path(mgf_path = path_to_mgf, n_best = 10)"
+    "spectra_matches = spec2vec.match_spectra_from_path(path_to_mgf, 10, [\"smiles\", \"compound_name\"])"
    ]
   },
   {
@@ -169,71 +158,121 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
+       "      <th>compound_name</th>\n",
        "      <th>score</th>\n",
+       "      <th>smiles</th>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>matches of spectrum #1</th>\n",
+       "      <th>matches of spectrum-0</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
        "      <th></th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>CCMSLIB00006015264</th>\n",
-       "      <td>0.231717</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>CCMSLIB00005914380</th>\n",
+       "      <td>Malvidin</td>\n",
        "      <td>0.221077</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>CCMSLIB00006056045</th>\n",
-       "      <td>0.191989</td>\n",
+       "      <td>OC=1C=C(O)C=2C=C(O)C(=[O+]C2C1)C=3C=C(OC)C(O)=...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>CCMSLIB00005914391</th>\n",
-       "      <td>0.189660</td>\n",
+       "      <td>Malvidin</td>\n",
+       "      <td>0.18966</td>\n",
+       "      <td>OC=1C=C(O)C=2C=C(O)C(=[O+]C2C1)C=3C=C(OC)C(O)=...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>CCMSLIB00005914553</th>\n",
-       "      <td>0.189660</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>CCMSLIB00006015384</th>\n",
-       "      <td>0.183075</td>\n",
+       "      <td>Malvidin</td>\n",
+       "      <td>0.18966</td>\n",
+       "      <td>OC=1C=C(O)C=2C=C(O)C(=[O+]C2C1)C=3C=C(OC)C(O)=...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>CCMSLIB00005987253</th>\n",
+       "      <td>Dephnoretin</td>\n",
        "      <td>0.158713</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>CCMSLIB00006056696</th>\n",
-       "      <td>0.157750</td>\n",
+       "      <td>O=C1OC=2C=C(OC3=CC=4C=C(OC)C(O)=CC4OC3=O)C=CC2...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>CCMSLIB00006015008</th>\n",
+       "      <td>3-(3,4-dihydro-2H-benzo[b][1,4]dioxepin-7-yl)-...</td>\n",
        "      <td>0.155292</td>\n",
+       "      <td>O=C1C2=CC=C(OCC)C=C2OC(=C1C=3C=CC=4OCCCOC4C3)C</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>CCMSLIB00006015264</th>\n",
+       "      <td>3-(3,4-dihydro-2H-benzo[b][1,4]dioxepin-7-yl)-...</td>\n",
+       "      <td>0.231717</td>\n",
+       "      <td>O=C1C2=CC=C(OCC)C=C2OC(=C1C=3C=CC=4OCCCOC4C3)C</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>CCMSLIB00006015384</th>\n",
+       "      <td>3-(3,4-dihydro-2H-benzo[b][1,4]dioxepin-7-yl)-...</td>\n",
+       "      <td>0.183075</td>\n",
+       "      <td>O=C1C2=CC=C(OCC)C=C2OC(=C1C=3C=CC=4OCCCOC4C3)C</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>CCMSLIB00006056025</th>\n",
+       "      <td>meso-dihydroguaiaretic acid</td>\n",
        "      <td>0.153557</td>\n",
+       "      <td>OC1=CC=C(C=C1OC)CC(C)C(C)CC2=CC=C(O)C(OC)=C2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>CCMSLIB00006056045</th>\n",
+       "      <td>meso-dihydroguaiaretic acid</td>\n",
+       "      <td>0.191989</td>\n",
+       "      <td>OC1=CC=C(C=C1OC)CC(C)C(C)CC2=CC=C(O)C(OC)=C2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>CCMSLIB00006056696</th>\n",
+       "      <td>meso-dihydroguaiaretic acid</td>\n",
+       "      <td>0.15775</td>\n",
+       "      <td>OC1=CC=C(C=C1OC)CC(C)C(C)CC2=CC=C(O)C(OC)=C2</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                           score\n",
-       "matches of spectrum #1          \n",
-       "CCMSLIB00006015264      0.231717\n",
-       "CCMSLIB00005914380      0.221077\n",
-       "CCMSLIB00006056045      0.191989\n",
-       "CCMSLIB00005914391      0.189660\n",
-       "CCMSLIB00005914553      0.189660\n",
-       "CCMSLIB00006015384      0.183075\n",
-       "CCMSLIB00005987253      0.158713\n",
-       "CCMSLIB00006056696      0.157750\n",
-       "CCMSLIB00006015008      0.155292\n",
-       "CCMSLIB00006056025      0.153557"
+       "                                                           compound_name  \\\n",
+       "matches of spectrum-0                                                      \n",
+       "CCMSLIB00005914380                                              Malvidin   \n",
+       "CCMSLIB00005914391                                              Malvidin   \n",
+       "CCMSLIB00005914553                                              Malvidin   \n",
+       "CCMSLIB00005987253                                           Dephnoretin   \n",
+       "CCMSLIB00006015008     3-(3,4-dihydro-2H-benzo[b][1,4]dioxepin-7-yl)-...   \n",
+       "CCMSLIB00006015264     3-(3,4-dihydro-2H-benzo[b][1,4]dioxepin-7-yl)-...   \n",
+       "CCMSLIB00006015384     3-(3,4-dihydro-2H-benzo[b][1,4]dioxepin-7-yl)-...   \n",
+       "CCMSLIB00006056025                           meso-dihydroguaiaretic acid   \n",
+       "CCMSLIB00006056045                           meso-dihydroguaiaretic acid   \n",
+       "CCMSLIB00006056696                           meso-dihydroguaiaretic acid   \n",
+       "\n",
+       "                          score  \\\n",
+       "matches of spectrum-0             \n",
+       "CCMSLIB00005914380     0.221077   \n",
+       "CCMSLIB00005914391      0.18966   \n",
+       "CCMSLIB00005914553      0.18966   \n",
+       "CCMSLIB00005987253     0.158713   \n",
+       "CCMSLIB00006015008     0.155292   \n",
+       "CCMSLIB00006015264     0.231717   \n",
+       "CCMSLIB00006015384     0.183075   \n",
+       "CCMSLIB00006056025     0.153557   \n",
+       "CCMSLIB00006056045     0.191989   \n",
+       "CCMSLIB00006056696      0.15775   \n",
+       "\n",
+       "                                                                  smiles  \n",
+       "matches of spectrum-0                                                     \n",
+       "CCMSLIB00005914380     OC=1C=C(O)C=2C=C(O)C(=[O+]C2C1)C=3C=C(OC)C(O)=...  \n",
+       "CCMSLIB00005914391     OC=1C=C(O)C=2C=C(O)C(=[O+]C2C1)C=3C=C(OC)C(O)=...  \n",
+       "CCMSLIB00005914553     OC=1C=C(O)C=2C=C(O)C(=[O+]C2C1)C=3C=C(OC)C(O)=...  \n",
+       "CCMSLIB00005987253     O=C1OC=2C=C(OC3=CC=4C=C(OC)C(O)=CC4OC3=O)C=CC2...  \n",
+       "CCMSLIB00006015008        O=C1C2=CC=C(OCC)C=C2OC(=C1C=3C=CC=4OCCCOC4C3)C  \n",
+       "CCMSLIB00006015264        O=C1C2=CC=C(OCC)C=C2OC(=C1C=3C=CC=4OCCCOC4C3)C  \n",
+       "CCMSLIB00006015384        O=C1C2=CC=C(OCC)C=C2OC(=C1C=3C=CC=4OCCCOC4C3)C  \n",
+       "CCMSLIB00006056025          OC1=CC=C(C=C1OC)CC(C)C(C)CC2=CC=C(O)C(OC)=C2  \n",
+       "CCMSLIB00006056045          OC1=CC=C(C=C1OC)CC(C)C(C)CC2=CC=C(O)C(OC)=C2  \n",
+       "CCMSLIB00006056696          OC1=CC=C(C=C1OC)CC(C)C(C)CC2=CC=C(O)C(OC)=C2  "
       ]
      },
      "execution_count": 6,
@@ -256,7 +295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/omigami/spec2vec.py
+++ b/omigami/spec2vec.py
@@ -191,8 +191,9 @@ class Spec2Vec:
 
     @staticmethod
     def _build_parameters(n_best: int, include_metadata: List[str]) -> Dict[str, Any]:
+        parameters = {}
         try:
-            n_best = int(n_best)
+            parameters["n_best_spectra"] = int(n_best)
         except ValueError:
             raise ValueError(
                 "The number of best features parameter must be an integer."
@@ -205,5 +206,6 @@ class Spec2Vec:
                         f"The metadata {key} is not included in the valid keys list. "
                         f"Please check documentation for the list of valid keys."
                     )
+            parameters["include_metadata"] = include_metadata
 
-        return {"n_best_spectra": n_best, "include_metadata": include_metadata}
+        return parameters


### PR DESCRIPTION
Fixes #19.
- Updates notebook and readme
- fixes error when calling the predictions with include_metadata as an empty list