### PR TITLE
MLOPS-358: Implement user credentials functionality

### DIFF
--- a/omigami/cli.py
+++ b/omigami/cli.py
@@ -1,0 +1,35 @@
+import click
+import os
+from cryptography.fernet import Fernet
+
+
+@click.command()
+@click.option("--username", help="Your Omigami.com username")
+@click.option("--password", help="Your Omigami.com password")
+@click.option(
+    "--unset",
+    is_flag=True,
+    help="Remove previously setup credentials for the current user",
+)
+def credentials_helper(username, password, unset):
+    """
+    CLI Helper for configuring the user machine to access the Omigami endpoints
+    """
+    path = os.path.expanduser("~") + "/.omigami/credentials"
+
+    if unset:
+        open(path, "w").close()
+        print("Crendetials successfully unset.")
+        return
+
+    key = Fernet.generate_key()
+    f = Fernet(key)
+    utoken = f.encrypt(password)
+    ptoken = f.encrypt(username)
+
+    with open(path, "w") as file:
+        file.write(utoken)
+        file.write(ptoken)
+        file.write(key)
+
+    print("Crendetials successfully saved.")

--- a/omigami/endpoint.py
+++ b/omigami/endpoint.py
@@ -37,10 +37,22 @@ def _sort_columns(df: pd.DataFrame):
 
 
 class Endpoint:
-    def __init__(self, token: str):
-        self._token = token
-        self.mandatory_keys = ["peaks_json", "Precursor_MZ"]
-        self.float_keys = ["Precursor_MZ"]
+    mandatory_keys: List[str] = ["peaks_json", "Precursor_MZ"]
+    float_keys: List[str] = ["Precursor_MZ"]
+
+    def __init__(self):
+        # WIP
+        credentials = self._get_saved_credentials()
+        if not credentials:
+            # maybe here ask if the user wants to set it up right now...
+            print(
+                "Warning, you have not setup your credentials yet. "
+                "Please do so by using 'omigami credentials-helper' CLI functionality and"
+                "then instantiate again your Spec2Vec client or run 'client.update_credentials()'"
+            )
+        else:
+            self._username = credentials["username"]
+            self._password = credentials["password"]
 
     @abstractmethod
     def match_spectra_from_path(
@@ -192,6 +204,9 @@ class Endpoint:
                             f"Passed value: {spectrum[key]}",
                             400,
                         )
+
+    def _authenticate(self):
+        pass
 
     @staticmethod
     def _format_results(api_request: requests.Response) -> List[pd.DataFrame]:

--- a/omigami/spec2vec.py
+++ b/omigami/spec2vec.py
@@ -49,6 +49,9 @@ class Spec2Vec(Endpoint):
         # defines endpoint based on user choice of spectra ion mode
         endpoint = self._PREDICT_ENDPOINT_BASE.format(ion_mode=ion_mode)
 
+        # gets token from user credentials
+        self._authenticate()
+
         parameters = self._build_parameters(n_best, include_metadata)
         # loads spectra
         spectra_generator = load_from_mgf(mgf_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ requests==2.24.0
 confuse==1.4.0
 matplotlib==3.4.2
 rdkit-pypi==2021.3.4
+click==8.0.1
+cryptography==3.4.7


### PR DESCRIPTION
Here we will be migrating from asking the user to paste his token in the client instantiation to having his credentials be saved in his machine using cryptography and then using these to get a session token everytime the user needs one automatically.

There is a CLI helper function to set up the credentials.
The objective is for this to be as easy and painless as possible for the user.

In the future, we might want to have a proper API token system and then get rid of credentials-based auth for the API client.